### PR TITLE
Apply mask to images

### DIFF
--- a/robocar/libcv/src/main/java/com/zugaldia/robocar/cv/LaneManager.java
+++ b/robocar/libcv/src/main/java/com/zugaldia/robocar/cv/LaneManager.java
@@ -51,6 +51,24 @@ public class LaneManager {
     return lines;
   }
 
+  /**
+   * Applies an image mask. Only keeps the region of the image defined by the
+   * polygon formed from `vertices`. The rest of the image is set to black.
+   */
+  public static opencv_core.Mat applyMask(opencv_core.Mat image) {
+    opencv_core.Mat mask = new opencv_core.Mat(image.size(), image.type());
+
+    // TODO: figure out how to set up and expose as method parameter
+    // Array of polygons where each polygon is represented as an array of points
+    opencv_core.MatVector points = new opencv_core.MatVector();
+    opencv_core.Scalar white = new opencv_core.Scalar(255, 255, 255, 0);
+    opencv_imgproc.fillPoly(mask, points, white);
+
+    opencv_core.Mat masked = new opencv_core.Mat();
+    opencv_core.bitwise_and(image, mask, masked);
+    return masked;
+  }
+
   public static void doDrawLine(opencv_core.Mat image, opencv_core.Point from, opencv_core.Point to, opencv_core.Scalar color, int thickness) {
     int lineType = opencv_core.LINE_8;
     int shift = 0;

--- a/robocar/libcv/src/main/java/com/zugaldia/robocar/cv/LaneManager.java
+++ b/robocar/libcv/src/main/java/com/zugaldia/robocar/cv/LaneManager.java
@@ -12,6 +12,8 @@ import org.bytedeco.javacpp.opencv_imgproc;
  */
 public class LaneManager {
 
+  private static final opencv_core.Scalar WHITE = new opencv_core.Scalar(255, 255, 255, 0);
+
   public static opencv_core.Mat readImage(String filename) {
     opencv_core.Mat image = opencv_imgcodecs.imread(filename);
     if (image.data() == null) {
@@ -55,16 +57,15 @@ public class LaneManager {
    * Applies an image mask. Only keeps the region of the image defined by the
    * polygon formed from `vertices`. The rest of the image is set to black.
    */
-  public static opencv_core.Mat applyMask(opencv_core.Mat image) {
+  public static opencv_core.Mat applyMask(opencv_core.Mat image, int[] points) {
     opencv_core.Mat mask = new opencv_core.Mat(image.size(), image.type());
 
-    // TODO: figure out how to set up and expose as method parameter
     // Array of polygons where each polygon is represented as an array of points
-    opencv_core.MatVector points = new opencv_core.MatVector();
-    opencv_core.Scalar white = new opencv_core.Scalar(255, 255, 255, 0);
-    opencv_imgproc.fillPoly(mask, points, white);
+    opencv_core.Point polygon = new opencv_core.Point();
+    polygon.put(points, 0, points.length);
+    opencv_imgproc.fillPoly(mask, polygon, new int[] {points.length / 2}, 1, WHITE);
 
-    opencv_core.Mat masked = new opencv_core.Mat();
+    opencv_core.Mat masked = new opencv_core.Mat(image.size(), image.type());
     opencv_core.bitwise_and(image, mask, masked);
     return masked;
   }

--- a/robocar/libcv/src/test/java/com/zugaldia/robocar/cv/LaneManagerTest.java
+++ b/robocar/libcv/src/test/java/com/zugaldia/robocar/cv/LaneManagerTest.java
@@ -75,6 +75,13 @@ public class LaneManagerTest {
   }
 
   @Test
+  public void testApplyMask() {
+    opencv_core.Mat src = LaneManager.readImage(getResourcePath("/test_images/solidWhiteRight.jpg"));
+    opencv_core.Mat masked = LaneManager.applyMask(src);
+    assertTrue(LaneManager.writeImage("/tmp/solidWhiteRight_masked.jpg", masked));
+  }
+
+  @Test
   public void testDrawLine() {
     opencv_core.Mat src = LaneManager.readImage(getResourcePath("/test_images/solidWhiteRight.jpg"));
     opencv_core.Scalar color = new opencv_core.Scalar(255, 0, 0, 0); // Blue (BGR)

--- a/robocar/libcv/src/test/java/com/zugaldia/robocar/cv/LaneManagerTest.java
+++ b/robocar/libcv/src/test/java/com/zugaldia/robocar/cv/LaneManagerTest.java
@@ -77,7 +77,11 @@ public class LaneManagerTest {
   @Test
   public void testApplyMask() {
     opencv_core.Mat src = LaneManager.readImage(getResourcePath("/test_images/solidWhiteRight.jpg"));
-    opencv_core.Mat masked = LaneManager.applyMask(src);
+    int[] points = new int[] {
+      0, src.size().height(), // bottom left
+      src.size().width() / 2, src.size().height() / 2, // middle point
+      src.size().width(), src.size().height()}; // // bottom right
+    opencv_core.Mat masked = LaneManager.applyMask(src, points);
     assertTrue(LaneManager.writeImage("/tmp/solidWhiteRight_masked.jpg", masked));
   }
 
@@ -104,10 +108,10 @@ public class LaneManagerTest {
     IntIndexer linesIndexer = lines.createIndexer();
     for (int i = 0; i < linesIndexer.rows(); i++) {
       for (int j = 0; j < linesIndexer.cols(); j++) {
-          LaneManager.doDrawLine(original,
-            new opencv_core.Point(linesIndexer.get(i, j, 0), linesIndexer.get(i, j, 1)),
-            new opencv_core.Point(linesIndexer.get(i, j, 2), linesIndexer.get(i, j, 3)),
-            color, 5);
+        LaneManager.doDrawLine(original,
+          new opencv_core.Point(linesIndexer.get(i, j, 0), linesIndexer.get(i, j, 1)),
+          new opencv_core.Point(linesIndexer.get(i, j, 2), linesIndexer.get(i, j, 3)),
+          color, 5);
       }
     }
 


### PR DESCRIPTION
We want to be able to apply a mask to images in order to remove from the analysis areas that are of no interest (e.g. sky). This PR adds this possibility.

Note this is still a WIP. We're hitting some issues with the API, any insights are much appreciated: http://stackoverflow.com/questions/42941016/translate-python-function-to-apply-mask-to-image-into-java/43142239.