### PR TITLE
Add Bluetooth support for NES30 controller

### DIFF
--- a/robocar/app/src/main/AndroidManifest.xml
+++ b/robocar/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application
         android:allowBackup="true"
+        android:name=".RobocarApp"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
@@ -1,14 +1,17 @@
 package com.zugaldia.robocar.app;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.KeyEvent;
 
 import com.zugaldia.robocar.hardware.adafruit2348.AdafruitDCMotor;
 import com.zugaldia.robocar.hardware.adafruit2348.AdafruitMotorHat;
+import com.zugaldia.robocar.software.controller.nes30.NES30Connection;
 import com.zugaldia.robocar.software.controller.nes30.NES30Listener;
 import com.zugaldia.robocar.software.controller.nes30.NES30Manager;
+
+import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity implements NES30Listener {
 
@@ -18,6 +21,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   private static final int MOTOR_SPEED = 255;
 
   private NES30Manager nes30Manager;
+  private NES30Connection nes30Connection;
   private boolean isMoving = false;
 
   private AdafruitMotorHat motorHat;
@@ -44,6 +48,20 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
     motorFrontRight.setSpeed(MOTOR_SPEED);
     motorBackRight = motorHat.getMotor(4);
     motorBackRight.setSpeed(MOTOR_SPEED);
+
+    // NES30 BT connection
+    setupBluetooth();
+  }
+
+  private void setupBluetooth() {
+    nes30Connection = new NES30Connection(
+            this, RobocarConstants.NES30_NAME, RobocarConstants.NES30_MAC_ADDRESS);
+
+    Timber.d("BT status: %b", nes30Connection.isEnabled());
+    Timber.d("Paired devices: %d", nes30Connection.getPairedDevices().size());
+    if (!nes30Connection.isPaired()) {
+      Timber.d("Start discovery: %b", nes30Connection.startDiscovery());
+    }
   }
 
   @Override
@@ -51,6 +69,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
     super.onDestroy();
     release();
     motorHat.close();
+    nes30Connection.cancelDiscovery();
   }
 
   /*

--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
@@ -2,7 +2,6 @@ package com.zugaldia.robocar.app;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.KeyEvent;
 
 import com.zugaldia.robocar.hardware.adafruit2348.AdafruitDCMotor;
@@ -14,8 +13,6 @@ import com.zugaldia.robocar.software.controller.nes30.NES30Manager;
 import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity implements NES30Listener {
-
-  private static final String LOG_TAG = MainActivity.class.getSimpleName();
 
   // Set the speed, from 0 (off) to 255 (max speed)
   private static final int MOTOR_SPEED = 255;
@@ -133,7 +130,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   }
 
   private void moveForward() {
-    Log.d(LOG_TAG, "Moving forward.");
+    Timber.d("Moving forward.");
     motorFrontLeft.run(AdafruitMotorHat.FORWARD);
     motorFrontRight.run(AdafruitMotorHat.BACKWARD);
     motorBackLeft.run(AdafruitMotorHat.BACKWARD);
@@ -141,7 +138,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   }
 
   private void moveBackward() {
-    Log.d(LOG_TAG, "Moving backward.");
+    Timber.d("Moving backward.");
     motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
     motorFrontRight.run(AdafruitMotorHat.FORWARD);
     motorBackLeft.run(AdafruitMotorHat.FORWARD);
@@ -149,7 +146,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   }
 
   private void turnLeft() {
-    Log.d(LOG_TAG, "Turning left.");
+    Timber.d("Turning left.");
     motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
     motorFrontRight.run(AdafruitMotorHat.BACKWARD);
     motorBackLeft.run(AdafruitMotorHat.FORWARD);
@@ -157,7 +154,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   }
 
   private void turnRight() {
-    Log.d(LOG_TAG, "Turning right.");
+    Timber.d("Turning right.");
     motorFrontLeft.run(AdafruitMotorHat.FORWARD);
     motorFrontRight.run(AdafruitMotorHat.FORWARD);
     motorBackLeft.run(AdafruitMotorHat.BACKWARD);
@@ -165,7 +162,7 @@ public class MainActivity extends AppCompatActivity implements NES30Listener {
   }
 
   private void release() {
-    Log.d(LOG_TAG, "Release.");
+    Timber.d("Release.");
     motorFrontLeft.run(AdafruitMotorHat.RELEASE);
     motorFrontRight.run(AdafruitMotorHat.RELEASE);
     motorBackLeft.run(AdafruitMotorHat.RELEASE);

--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/RobocarApp.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/RobocarApp.java
@@ -1,0 +1,20 @@
+package com.zugaldia.robocar.app;
+
+import android.app.Application;
+
+import timber.log.Timber;
+
+/**
+ * Created by antonio on 4/21/17.
+ */
+
+public class RobocarApp extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree());
+        }
+    }
+}

--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/RobocarConstants.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/RobocarConstants.java
@@ -1,0 +1,14 @@
+package com.zugaldia.robocar.app;
+
+/**
+ * Use this class to customize your set up
+ */
+public class RobocarConstants {
+
+    // Fill out these fields if you want the app to try to automatically connect
+    // to your NES30 controller via Bluetooth. If you plan on using USB (e.g. during
+    // development) you don't need to worry about this.
+    public static final String NES30_NAME = "8Bitdo NES30 GamePad";
+    public static final String NES30_MAC_ADDRESS = "E4:17:D8:EA:66:68";
+
+}

--- a/robocar/libcv/build.gradle
+++ b/robocar/libcv/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // JavaCV
     compile 'org.bytedeco.javacpp-presets:opencv-platform:3.2.0-1.3'
 
+    // Logging
+    compile 'com.jakewharton.timber:timber:4.5.1'
+
     // Testing
     testCompile 'junit:junit:4.12'
 }

--- a/robocar/libcv/src/main/AndroidManifest.xml
+++ b/robocar/libcv/src/main/AndroidManifest.xml
@@ -1,13 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.zugaldia.robocar.cv">
 
-          package="com.zugaldia.robocar.cv"
->
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+    <application />
 
 </manifest>

--- a/robocar/libhardware/build.gradle
+++ b/robocar/libhardware/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // Android Things
     provided 'com.google.android.things:androidthings:0.3-devpreview'
 
+    // Logging
+    compile 'com.jakewharton.timber:timber:4.5.1'
+
     // Testing
     testCompile 'junit:junit:4.12'
 }

--- a/robocar/libhardware/src/main/AndroidManifest.xml
+++ b/robocar/libhardware/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.zugaldia.robocar.hardware">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+    <application/>
 
 </manifest>

--- a/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitPwm.java
+++ b/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitPwm.java
@@ -1,11 +1,11 @@
 package com.zugaldia.robocar.hardware.adafruit2348;
 
-import android.util.Log;
-
 import com.google.android.things.pio.I2cDevice;
 import com.google.android.things.pio.PeripheralManagerService;
 
 import java.io.IOException;
+
+import timber.log.Timber;
 
 /**
  * A port of `Adafruit_PWM_Servo_Driver` (Adafruit PCA9685 16-Channel PWM Servo
@@ -17,8 +17,6 @@ import java.io.IOException;
  */
 
 public class AdafruitPwm {
-
-  private static final String LOG_TAG = AdafruitPwm.class.getSimpleName();
 
   public static final String I2C_DEVICE_NAME = "I2C1";
   public static final int I2C_ADDRESS = 0x60;
@@ -56,11 +54,11 @@ public class AdafruitPwm {
   public AdafruitPwm(String deviceName, int address, boolean debug) {
     try {
       // Attempt to access the I2C device
-      Log.d(LOG_TAG, String.format("Connecting to I2C device %s @ 0x%02X.", deviceName, address));
+      Timber.d("Connecting to I2C device %s @ 0x%02X.", deviceName, address);
       PeripheralManagerService manager = new PeripheralManagerService();
       i2c = manager.openI2cDevice(deviceName, address);
     } catch (IOException e) {
-      Log.w(LOG_TAG, "Unable to access I2C device:", e);
+      Timber.w(e, "Unable to access I2C device.");
     }
 
     this.debug = debug;
@@ -69,7 +67,7 @@ public class AdafruitPwm {
 
   private void reset() {
     if (debug) {
-      Log.d(LOG_TAG, "Resetting PCA9685 MODE1 (without SLEEP) and MODE2.");
+      Timber.d("Resetting PCA9685 MODE1 (without SLEEP) and MODE2.");
     }
 
     setAllPWM(0, 0);
@@ -89,7 +87,7 @@ public class AdafruitPwm {
         i2c.close();
         i2c = null;
       } catch (IOException e) {
-        Log.w(LOG_TAG, "Unable to close I2C device:", e);
+        Timber.w(e, "Unable to close I2C device.");
       }
     }
   }
@@ -103,13 +101,13 @@ public class AdafruitPwm {
     prescaleval /= (float) freq;
     prescaleval -= 1.0;
     if (debug) {
-      Log.d(LOG_TAG, String.format("Setting PWM frequency to %d Hz", freq));
-      Log.d(LOG_TAG, String.format("Estimated pre-scale: %f", prescaleval));
+      Timber.d("Setting PWM frequency to %d Hz", freq);
+      Timber.d("Estimated pre-scale: %f", prescaleval);
     }
 
     double prescale = Math.floor(prescaleval + 0.5);
     if (debug) {
-      Log.d(LOG_TAG, String.format("Final pre-scale: %f", prescale));
+      Timber.d("Final pre-scale: %f", prescale);
     }
 
     byte oldmode = readRegByteWrapped(__MODE1);
@@ -145,7 +143,7 @@ public class AdafruitPwm {
     try {
       Thread.sleep((long) (seconds * 1000));
     } catch (InterruptedException e) {
-      Log.e(LOG_TAG, "sleepWrapped failed: " + e.getMessage());
+      Timber.e(e, "sleepWrapped failed.");
     }
   }
 
@@ -153,12 +151,12 @@ public class AdafruitPwm {
     try {
       i2c.writeRegByte(reg, data);
     } catch (IOException e) {
-      Log.e(LOG_TAG, String.format("writeRegByte to 0x%02X failed: %s", reg, e.getMessage()));
+      Timber.e(e, "writeRegByte to 0x%02X failed: %s", reg);
       return;
     }
 
     if (debug) {
-      Log.d(LOG_TAG, String.format("Wrote to register 0x%02X: 0x%02X", reg, data));
+      Timber.d("Wrote to register 0x%02X: 0x%02X", reg, data);
     }
   }
 
@@ -168,11 +166,11 @@ public class AdafruitPwm {
     try {
       data = i2c.readRegByte(reg);
     } catch (IOException e) {
-      Log.e(LOG_TAG, String.format("readRegByte from 0x%02X failed: %s", reg, e.getMessage()));
+      Timber.d(e, "readRegByte from 0x%02X failed: %s", reg);
     }
 
     if (debug) {
-      Log.d(LOG_TAG, String.format("Read from register 0x%02X: 0x%02X", reg, data));
+      Timber.d("Read from register 0x%02X: 0x%02X", reg, data);
     }
 
     return data;

--- a/robocar/libsoftware/build.gradle
+++ b/robocar/libsoftware/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // Android Support Libraries
     compile 'com.android.support:support-annotations:25.3.1'
 
+    // Logging
+    compile 'com.jakewharton.timber:timber:4.5.1'
+
     // Testing
     testCompile 'junit:junit:4.12'
 }

--- a/robocar/libsoftware/src/main/AndroidManifest.xml
+++ b/robocar/libsoftware/src/main/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.zugaldia.robocar.software">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
+    <!-- NES30 controller -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
-    </application>
+    <application/>
 
 </manifest>

--- a/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/controller/nes30/NES30Connection.java
+++ b/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/controller/nes30/NES30Connection.java
@@ -1,0 +1,111 @@
+package com.zugaldia.robocar.software.controller.nes30;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.text.TextUtils;
+
+import java.util.Set;
+
+import timber.log.Timber;
+
+/**
+ * Manages the Bluetooth connection to the NES30 controller
+ */
+public class NES30Connection {
+
+    private Context context;
+    private String deviceAddress;
+    private String deviceName;
+
+    private BluetoothAdapter bluetoothAdapter;
+
+    public NES30Connection(Context context, String deviceName, String deviceAddress) {
+        this.context = context;
+        this.deviceName = deviceName;
+        this.deviceAddress = deviceAddress;
+        bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (bluetoothAdapter == null) {
+            Timber.e("This device does not support Bluetooth.");
+        } else if (!isEnabled()) {
+            Timber.d("Bluetooth isn't enabled, enabling: %b", bluetoothAdapter.enable());
+        }
+    }
+
+    public boolean isEnabled() {
+        return (bluetoothAdapter != null && bluetoothAdapter.isEnabled());
+    }
+
+    public Set<BluetoothDevice> getPairedDevices() {
+        return bluetoothAdapter.getBondedDevices();
+    }
+
+    public boolean isPaired() {
+        Set<BluetoothDevice> pairedDevices = getPairedDevices();
+        for (BluetoothDevice pairedDevice: pairedDevices) {
+            if (isKnownDevice(pairedDevice.getName(), pairedDevice.getAddress())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean startDiscovery() {
+        registerReceiver();
+        return bluetoothAdapter.startDiscovery();
+    }
+
+    // Create a BroadcastReceiver for ACTION_FOUND.
+    private final BroadcastReceiver receiver = new BroadcastReceiver() {
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            // Discovery has found a device.
+            if (BluetoothDevice.ACTION_FOUND.equals(action)) {
+                // Get the BluetoothDevice object and its info from the Intent.
+                BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                int bondState = device.getBondState();
+                String foundName = device.getName();
+                String foundAddress = device.getAddress(); // MAC address
+                Timber.d("Discovery has found a device: %d/%s/%s", bondState, foundName, foundAddress);
+                if (isKnownDevice(foundName, foundAddress)) {
+                    createBond(device);
+                } else {
+                    Timber.d("Unknown device, skipping bond attempt.");
+                }
+            }
+        }
+    };
+
+    private void registerReceiver() {
+        // Register for broadcasts when a device is discovered.
+        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_FOUND);
+        context.registerReceiver(receiver, filter);
+    }
+
+    public void cancelDiscovery() {
+        bluetoothAdapter.cancelDiscovery();
+        context.unregisterReceiver(receiver);
+    }
+
+    private boolean isKnownDevice(String foundName, String foundAddress) {
+        if (!TextUtils.isEmpty(deviceName) && deviceName.equals(foundName)) {
+            // Name is set and recognized
+            return true;
+        } else if (!TextUtils.isEmpty(deviceAddress) && deviceAddress.equals(foundAddress)) {
+            // MAC address is set and recognized
+            return true;
+        }
+
+        return false;
+    }
+
+    private void createBond(BluetoothDevice device) {
+        Timber.d("Creating bond with: %s/%s/%b",
+                device.getName(), device.getAddress(), device.createBond());
+    }
+
+}

--- a/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/controller/nes30/NES30Manager.java
+++ b/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/controller/nes30/NES30Manager.java
@@ -1,7 +1,6 @@
 package com.zugaldia.robocar.software.controller.nes30;
 
 import android.support.annotation.IntDef;
-import android.util.Log;
 import android.view.KeyEvent;
 
 import java.lang.annotation.Retention;
@@ -10,13 +9,13 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 
+import timber.log.Timber;
+
 /**
  * Manage NES30 controller key events
  */
 
 public class NES30Manager implements KeyEvent.Callback {
-
-  private final static String LOG_TAG = NES30Manager.class.getSimpleName();
 
   @Retention(RetentionPolicy.SOURCE)
   @IntDef( {BUTTON_LEFT_CODE, BUTTON_RIGHT_CODE, BUTTON_UP_CODE, BUTTON_DOWN_CODE,
@@ -92,14 +91,14 @@ public class NES30Manager implements KeyEvent.Callback {
   @Override
   public boolean onKeyLongPress(int keyCode, KeyEvent event) {
     // NOTE: Doesn't seem to be triggered
-    Log.d(LOG_TAG, String.format("onKeyLongPress: %d", keyCode));
+    Timber.d("onKeyLongPress: %d", keyCode);
     return false;
   }
 
   @Override
   public boolean onKeyMultiple(int keyCode, int count, KeyEvent event) {
     // NOTE: Doesn't seem to be triggered
-    Log.d(LOG_TAG, String.format("onKeyMultiple: %d", keyCode));
+    Timber.d("onKeyMultiple: %d", keyCode);
     return false;
   }
 


### PR DESCRIPTION
The latest dev preview of Android Things adds [support for the Bluetooth API](https://developer.android.com/things/preview/releases.html):

> Developers can now use the Android Bluetooth APIs across all Android Things supported hardware. These APIs can be used to interact with both Classic Bluetooth and Bluetooth Low Energy (BLE) devices. See the Samples page for Bluetooth audio and Bluetooth GATT server code samples.

This PRs adds a new class to automatically bond (pair) the NES30 controller to the Robocar.