### PR TITLE
Increase photo taking + storage speed

### DIFF
--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
@@ -334,7 +334,7 @@ public class MainActivity extends AppCompatActivity
           public void run() {
             cameraOperator.takePicture();
           }
-        }, 0, 500); // 0 delay, 500 period
+        }, 0, 250); // 0 delay, 250 period
         break;
     }
   }

--- a/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/camera/CameraOperator.java
+++ b/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/camera/CameraOperator.java
@@ -43,7 +43,7 @@ public class CameraOperator implements
   private static final int IMAGE_WIDTH = 320;
   private static final int IMAGE_HEIGHT = 240;
   private static final int IMAGE_FORMAT = ImageFormat.JPEG;
-  private static final int MAX_IMAGES = 2;
+  private static final int MAX_IMAGES = 5;
   private static final String ROBOCAR_FOLDER = "robocar";
   private static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.US);
 
@@ -249,7 +249,7 @@ public class CameraOperator implements
         speeds[0], speeds[1], speeds[2], speeds[3]);
     String filename = String.format(Locale.US, "robocar-%s-%d-%s-%s.jpg",
         sessionId, sessionCount++, timestamp, speedState);
-    backgroundHandler.post(new ImageSaver(reader.acquireNextImage(), root, filename));
+    backgroundHandler.post(new ImageSaver(reader.acquireLatestImage(), root, filename));
   }
 
   /**

--- a/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/camera/ImageSaver.java
+++ b/robocar/libsoftware/src/main/java/com/zugaldia/robocar/software/camera/ImageSaver.java
@@ -27,6 +27,11 @@ public class ImageSaver implements Runnable {
 
   @Override
   public void run() {
+    if (image == null) {
+      Timber.w("Empty image, skipping.");
+      return;
+    }
+
     ByteBuffer buffer = image.getPlanes()[0].getBuffer();
     byte[] bytes = new byte[buffer.remaining()];
     buffer.get(bytes);


### PR DESCRIPTION
@hsalameh These are the changes we discussed yesterday. We still need to research if there's a better way to handle the image buffer, but this solves the crash for now while reducing the time between shots to 250ms.