### PR TITLE
Refactored AdafruitMotorHat and AdafruitPwm constructors to allow stacking of other hats

### DIFF
--- a/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
+++ b/robocar/app/src/main/java/com/zugaldia/robocar/app/MainActivity.java
@@ -20,329 +20,333 @@ import com.zugaldia.robocar.software.webserver.models.RobocarResponse;
 import com.zugaldia.robocar.software.webserver.models.RobocarSpeed;
 import com.zugaldia.robocar.software.webserver.models.RobocarStatus;
 
-import fi.iki.elonen.NanoHTTPD;
-
 import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import fi.iki.elonen.NanoHTTPD;
 import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity
-    implements Nes30Listener, RequestListener, SpeedOwner, CameraOperatorListener {
+        implements Nes30Listener, RequestListener, SpeedOwner, CameraOperatorListener {
 
-  // Set the speed, from 0 (off) to 255 (max speed)
-  private static final int MOTOR_SPEED = 255;
-  private static final int MOTOR_SPEED_SLOW = 95;
+    // Set the speed, from 0 (off) to 255 (max speed)
+    private static final int MOTOR_SPEED = 255;
+    private static final int MOTOR_SPEED_SLOW = 95;
 
-  private Nes30Manager nes30Manager;
-  private Nes30Connection nes30Connection;
-  private boolean isMoving = false;
+    private Nes30Manager nes30Manager;
+    private Nes30Connection nes30Connection;
+    private boolean isMoving = false;
 
-  private AdafruitMotorHat motorHat;
-  private AdafruitDcMotor motorFrontLeft;
-  private AdafruitDcMotor motorFrontRight;
-  private AdafruitDcMotor motorBackLeft;
-  private AdafruitDcMotor motorBackRight;
+    private AdafruitMotorHat motorHat;
+    private AdafruitDcMotor motorFrontLeft;
+    private AdafruitDcMotor motorFrontRight;
+    private AdafruitDcMotor motorBackLeft;
+    private AdafruitDcMotor motorBackRight;
 
-  //TODO: refactoring: make these into a class, maybe call it ButtonPressStates
-  private boolean isUpPressed = false;
-  private boolean isDownPressed = false;
-  private boolean isLeftPressed = false;
-  private boolean isRightPressed = false;
-  private boolean isUpOrDownPressed = false;
-  private boolean allButtonsReleased = true;
+    //TODO: refactoring: make these into a class, maybe call it ButtonPressStates
+    private boolean isUpPressed = false;
+    private boolean isDownPressed = false;
+    private boolean isLeftPressed = false;
+    private boolean isRightPressed = false;
+    private boolean isUpOrDownPressed = false;
+    private boolean allButtonsReleased = true;
 
-  private CameraOperator cameraOperator;
-  private Timer timer;
-  private int cameraMode;
-  private static final int CAMERA_MODE_ONE = 1;
-  private static final int CAMERA_MODE_MULTIPLE = 2;
+    private CameraOperator cameraOperator;
+    private Timer timer;
+    private int cameraMode;
+    private static final int CAMERA_MODE_ONE = 1;
+    private static final int CAMERA_MODE_MULTIPLE = 2;
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
+    // I2C Name
+    public static final String I2C_DEVICE_NAME = "I2C1";
+    // Adafruit Motor Hat
+    private static final int MOTOR_HAT_I2C_ADDRESS = 0x60;
 
-    // Controller
-    nes30Manager = new Nes30Manager(this);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
 
-    // Motors
-    motorHat = new AdafruitMotorHat();
-    motorFrontLeft = motorHat.getMotor(1);
-    motorBackLeft = motorHat.getMotor(2);
-    motorFrontRight = motorHat.getMotor(3);
-    motorBackRight = motorHat.getMotor(4);
+        // Controller
+        nes30Manager = new Nes30Manager(this);
 
-    // Local web server
-    setupWebServer();
+        // Motors
+        motorHat = new AdafruitMotorHat(I2C_DEVICE_NAME, MOTOR_HAT_I2C_ADDRESS);
+        motorFrontLeft = motorHat.getMotor(1);
+        motorBackLeft = motorHat.getMotor(2);
+        motorFrontRight = motorHat.getMotor(3);
+        motorBackRight = motorHat.getMotor(4);
 
-    // NES30 BT connection
-    setupBluetooth();
+        // Local web server
+        setupWebServer();
 
-    // Camera
-    cameraOperator = new CameraOperator(this, this, this);
-  }
+        // NES30 BT connection
+        setupBluetooth();
 
-  @Override
-  public int[] getSpeeds() {
-    return new int[] {
-        motorHat.getMotor(1).getLastSpeed(),
-        motorHat.getMotor(2).getLastSpeed(),
-        motorHat.getMotor(3).getLastSpeed(),
-        motorHat.getMotor(4).getLastSpeed()};
-  }
-
-  private void setMotorSpeedsBasedOnButtonsPressed() {
-
-    boolean isLowSpeedOnLeft = isLeftPressed && isUpOrDownPressed;
-    boolean isLowSpeedOnRight = isRightPressed && isUpOrDownPressed;
-
-    int speedLeft = isLowSpeedOnLeft ? MOTOR_SPEED_SLOW : MOTOR_SPEED;
-    int speedRight = isLowSpeedOnRight ? MOTOR_SPEED_SLOW : MOTOR_SPEED;
-
-    motorFrontLeft.setSpeed(speedLeft);
-    motorBackLeft.setSpeed(speedLeft);
-    motorFrontRight.setSpeed(speedRight);
-    motorBackRight.setSpeed(speedRight);
-  }
-
-  private void setupWebServer() {
-    LocalWebServer localWebServer = new LocalWebServer(this);
-    try {
-      localWebServer.start();
-    } catch (IOException e) {
-      Timber.e(e, "Failed to start local web server.");
+        // Camera
+        cameraOperator = new CameraOperator(this, this, this);
     }
-  }
 
-  private void setupBluetooth() {
-    nes30Connection = new Nes30Connection(
-        this, RobocarConstants.NES30_NAME, RobocarConstants.NES30_MAC_ADDRESS);
-
-    Timber.d("BT status: %b", nes30Connection.isEnabled());
-    Timber.d("Paired devices: %d", nes30Connection.getPairedDevices().size());
-    BluetoothDevice nes30device = nes30Connection.isPaired();
-    if (nes30device == null) {
-      Timber.d("Starting discovery: %b", nes30Connection.startDiscovery());
-    } else {
-      Timber.d("Creating bond: %b", nes30Connection.createBond(nes30device));
+    @Override
+    public int[] getSpeeds() {
+        return new int[]{
+                motorHat.getMotor(1).getLastSpeed(),
+                motorHat.getMotor(2).getLastSpeed(),
+                motorHat.getMotor(3).getLastSpeed(),
+                motorHat.getMotor(4).getLastSpeed()};
     }
-  }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    release();
-    motorHat.close();
-    nes30Connection.cancelDiscovery();
-    endSession();
-  }
+    private void setMotorSpeedsBasedOnButtonsPressed() {
+
+        boolean isLowSpeedOnLeft = isLeftPressed && isUpOrDownPressed;
+        boolean isLowSpeedOnRight = isRightPressed && isUpOrDownPressed;
+
+        int speedLeft = isLowSpeedOnLeft ? MOTOR_SPEED_SLOW : MOTOR_SPEED;
+        int speedRight = isLowSpeedOnRight ? MOTOR_SPEED_SLOW : MOTOR_SPEED;
+
+        motorFrontLeft.setSpeed(speedLeft);
+        motorBackLeft.setSpeed(speedLeft);
+        motorFrontRight.setSpeed(speedRight);
+        motorBackRight.setSpeed(speedRight);
+    }
+
+    private void setupWebServer() {
+        LocalWebServer localWebServer = new LocalWebServer(this);
+        try {
+            localWebServer.start();
+        } catch (IOException e) {
+            Timber.e(e, "Failed to start local web server.");
+        }
+    }
+
+    private void setupBluetooth() {
+        nes30Connection = new Nes30Connection(
+                this, RobocarConstants.NES30_NAME, RobocarConstants.NES30_MAC_ADDRESS);
+
+        Timber.d("BT status: %b", nes30Connection.isEnabled());
+        Timber.d("Paired devices: %d", nes30Connection.getPairedDevices().size());
+        BluetoothDevice nes30device = nes30Connection.isPaired();
+        if (nes30device == null) {
+            Timber.d("Starting discovery: %b", nes30Connection.startDiscovery());
+        } else {
+            Timber.d("Creating bond: %b", nes30Connection.createBond(nes30device));
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        release();
+        motorHat.close();
+        nes30Connection.cancelDiscovery();
+        endSession();
+    }
 
   /*
    * Handle keyboard (controller) events
    */
 
-  @Override
-  public boolean onKeyDown(int keyCode, KeyEvent event) {
-    return nes30Manager.onKeyDown(keyCode, event);
-  }
-
-  @Override
-  public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-    return nes30Manager.onKeyLongPress(keyCode, event);
-  }
-
-  @Override
-  public boolean onKeyUp(int keyCode, KeyEvent event) {
-    return nes30Manager.onKeyUp(keyCode, event);
-  }
-
-  @Override
-  public boolean onKeyMultiple(int keyCode, int count, KeyEvent event) {
-    return nes30Manager.onKeyMultiple(keyCode, count, event);
-  }
-
-  @Override
-  public void onKeyPress(@Nes30Manager.ButtonCode int keyCode, boolean isDown) {
-    updateButtonPressedStates(keyCode, isDown);
-
-    if (allButtonsReleased && isMoving) {
-      isMoving = false;
-      release();
-      return;
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return nes30Manager.onKeyDown(keyCode, event);
     }
-    // We start moving the moment the key is pressed
-    isMoving = true;
 
-    setMotorSpeedsBasedOnButtonsPressed();
+    @Override
+    public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+        return nes30Manager.onKeyLongPress(keyCode, event);
+    }
 
-    switch (keyCode) {
-      case Nes30Manager.BUTTON_UP_CODE:
-        moveForward();
-        break;
-      case Nes30Manager.BUTTON_DOWN_CODE:
-        moveBackward();
-        break;
-      case Nes30Manager.BUTTON_LEFT_CODE:
-        if (!isUpOrDownPressed) {
-          turnLeft();
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        return nes30Manager.onKeyUp(keyCode, event);
+    }
+
+    @Override
+    public boolean onKeyMultiple(int keyCode, int count, KeyEvent event) {
+        return nes30Manager.onKeyMultiple(keyCode, count, event);
+    }
+
+    @Override
+    public void onKeyPress(@Nes30Manager.ButtonCode int keyCode, boolean isDown) {
+        updateButtonPressedStates(keyCode, isDown);
+
+        if (allButtonsReleased && isMoving) {
+            isMoving = false;
+            release();
+            return;
         }
-        break;
-      case Nes30Manager.BUTTON_RIGHT_CODE:
-        if (!isUpOrDownPressed) {
-          turnRight();
+        // We start moving the moment the key is pressed
+        isMoving = true;
+
+        setMotorSpeedsBasedOnButtonsPressed();
+
+        switch (keyCode) {
+            case Nes30Manager.BUTTON_UP_CODE:
+                moveForward();
+                break;
+            case Nes30Manager.BUTTON_DOWN_CODE:
+                moveBackward();
+                break;
+            case Nes30Manager.BUTTON_LEFT_CODE:
+                if (!isUpOrDownPressed) {
+                    turnLeft();
+                }
+                break;
+            case Nes30Manager.BUTTON_RIGHT_CODE:
+                if (!isUpOrDownPressed) {
+                    turnRight();
+                }
+                break;
+            case Nes30Manager.BUTTON_X_CODE:
+                if (isDown) {
+                    Timber.d("Starting camera session for single pics.");
+                    cameraMode = CAMERA_MODE_ONE;
+                    startSession();
+                }
+                break;
+            case Nes30Manager.BUTTON_Y_CODE:
+                if (isDown) {
+                    Timber.d("Starting camera session for multiple pics.");
+                    cameraMode = CAMERA_MODE_MULTIPLE;
+                    startSession();
+                }
+                break;
+            case Nes30Manager.BUTTON_A_CODE:
+                if (isDown) {
+                    Timber.d("Stopping camera session.");
+                    endSession();
+                }
+                break;
+            case Nes30Manager.BUTTON_KONAMI:
+                // Do your magic here ;-)
+                break;
+            default:
+                // No action
+                break;
         }
-        break;
-      case Nes30Manager.BUTTON_X_CODE:
-        if (isDown) {
-          Timber.d("Starting camera session for single pics.");
-          cameraMode = CAMERA_MODE_ONE;
-          startSession();
+    }
+
+    private void updateButtonPressedStates(@Nes30Manager.ButtonCode int keyCode, boolean isDown) {
+        switch (keyCode) {
+            case Nes30Manager.BUTTON_UP_CODE:
+                isUpPressed = isDown;
+                break;
+            case Nes30Manager.BUTTON_DOWN_CODE:
+                isDownPressed = isDown;
+                break;
+            case Nes30Manager.BUTTON_LEFT_CODE:
+                isLeftPressed = isDown;
+                break;
+            case Nes30Manager.BUTTON_RIGHT_CODE:
+                isRightPressed = isDown;
+                break;
+            default:
+                // No action
+                break;
         }
-        break;
-      case Nes30Manager.BUTTON_Y_CODE:
-        if (isDown) {
-          Timber.d("Starting camera session for multiple pics.");
-          cameraMode = CAMERA_MODE_MULTIPLE;
-          startSession();
+
+        isUpOrDownPressed = isUpPressed || isDownPressed;
+
+        allButtonsReleased = !(isUpPressed || isDownPressed || isLeftPressed || isRightPressed);
+    }
+
+    private void moveForward() {
+        Timber.d("Moving forward.");
+        motorFrontLeft.run(AdafruitMotorHat.FORWARD);
+        motorFrontRight.run(AdafruitMotorHat.BACKWARD);
+        motorBackLeft.run(AdafruitMotorHat.BACKWARD);
+        motorBackRight.run(AdafruitMotorHat.FORWARD);
+    }
+
+    private void moveBackward() {
+        Timber.d("Moving backward.");
+        motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
+        motorFrontRight.run(AdafruitMotorHat.FORWARD);
+        motorBackLeft.run(AdafruitMotorHat.FORWARD);
+        motorBackRight.run(AdafruitMotorHat.BACKWARD);
+    }
+
+    private void turnLeft() {
+        Timber.d("Turning left.");
+        motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
+        motorFrontRight.run(AdafruitMotorHat.BACKWARD);
+        motorBackLeft.run(AdafruitMotorHat.FORWARD);
+        motorBackRight.run(AdafruitMotorHat.FORWARD);
+    }
+
+    private void turnRight() {
+        Timber.d("Turning right.");
+        motorFrontLeft.run(AdafruitMotorHat.FORWARD);
+        motorFrontRight.run(AdafruitMotorHat.FORWARD);
+        motorBackLeft.run(AdafruitMotorHat.BACKWARD);
+        motorBackRight.run(AdafruitMotorHat.BACKWARD);
+    }
+
+    private void release() {
+        Timber.d("Release.");
+        motorFrontLeft.run(AdafruitMotorHat.RELEASE);
+        motorFrontRight.run(AdafruitMotorHat.RELEASE);
+        motorBackLeft.run(AdafruitMotorHat.RELEASE);
+        motorBackRight.run(AdafruitMotorHat.RELEASE);
+    }
+
+    @Override
+    public void onRequest(NanoHTTPD.IHTTPSession session) {
+        LocalWebServer.logSession(session);
+    }
+
+    @Override
+    public RobocarStatus onStatus() {
+        return new RobocarStatus(200, "OK");
+    }
+
+    @Override
+    public RobocarResponse onMove(RobocarMove move) {
+        return new RobocarResponse(200, "TODO");
+    }
+
+    @Override
+    public RobocarResponse onSpeed(RobocarSpeed speed) {
+        if (speed == null) {
+            return new RobocarResponse(400, "Bad Request");
         }
-        break;
-      case Nes30Manager.BUTTON_A_CODE:
-        if (isDown) {
-          Timber.d("Stopping camera session.");
-          endSession();
+        RobocarSpeedChanger speedChanger = new RobocarSpeedChanger(
+                motorFrontLeft, motorFrontRight, motorBackLeft, motorBackRight);
+        speedChanger.changeSpeed(speed);
+        return new RobocarResponse(200, "OK");
+    }
+
+    private void startSession() {
+        if (!cameraOperator.isInSession()) {
+            cameraOperator.startSession();
+        } else if (cameraMode == CAMERA_MODE_ONE) {
+            sessionStarted();
         }
-        break;
-      case Nes30Manager.BUTTON_KONAMI:
-        // Do your magic here ;-)
-        break;
-      default:
-        // No action
-        break;
-    }
-  }
-
-  private void updateButtonPressedStates(@Nes30Manager.ButtonCode int keyCode, boolean isDown) {
-    switch (keyCode) {
-      case Nes30Manager.BUTTON_UP_CODE:
-        isUpPressed = isDown;
-        break;
-      case Nes30Manager.BUTTON_DOWN_CODE:
-        isDownPressed = isDown;
-        break;
-      case Nes30Manager.BUTTON_LEFT_CODE:
-        isLeftPressed = isDown;
-        break;
-      case Nes30Manager.BUTTON_RIGHT_CODE:
-        isRightPressed = isDown;
-        break;
-      default:
-        // No action
-        break;
     }
 
-    isUpOrDownPressed = isUpPressed || isDownPressed;
-
-    allButtonsReleased = !(isUpPressed || isDownPressed || isLeftPressed || isRightPressed);
-  }
-
-  private void moveForward() {
-    Timber.d("Moving forward.");
-    motorFrontLeft.run(AdafruitMotorHat.FORWARD);
-    motorFrontRight.run(AdafruitMotorHat.BACKWARD);
-    motorBackLeft.run(AdafruitMotorHat.BACKWARD);
-    motorBackRight.run(AdafruitMotorHat.FORWARD);
-  }
-
-  private void moveBackward() {
-    Timber.d("Moving backward.");
-    motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
-    motorFrontRight.run(AdafruitMotorHat.FORWARD);
-    motorBackLeft.run(AdafruitMotorHat.FORWARD);
-    motorBackRight.run(AdafruitMotorHat.BACKWARD);
-  }
-
-  private void turnLeft() {
-    Timber.d("Turning left.");
-    motorFrontLeft.run(AdafruitMotorHat.BACKWARD);
-    motorFrontRight.run(AdafruitMotorHat.BACKWARD);
-    motorBackLeft.run(AdafruitMotorHat.FORWARD);
-    motorBackRight.run(AdafruitMotorHat.FORWARD);
-  }
-
-  private void turnRight() {
-    Timber.d("Turning right.");
-    motorFrontLeft.run(AdafruitMotorHat.FORWARD);
-    motorFrontRight.run(AdafruitMotorHat.FORWARD);
-    motorBackLeft.run(AdafruitMotorHat.BACKWARD);
-    motorBackRight.run(AdafruitMotorHat.BACKWARD);
-  }
-
-  private void release() {
-    Timber.d("Release.");
-    motorFrontLeft.run(AdafruitMotorHat.RELEASE);
-    motorFrontRight.run(AdafruitMotorHat.RELEASE);
-    motorBackLeft.run(AdafruitMotorHat.RELEASE);
-    motorBackRight.run(AdafruitMotorHat.RELEASE);
-  }
-
-  @Override
-  public void onRequest(NanoHTTPD.IHTTPSession session) {
-    LocalWebServer.logSession(session);
-  }
-
-  @Override
-  public RobocarStatus onStatus() {
-    return new RobocarStatus(200, "OK");
-  }
-
-  @Override
-  public RobocarResponse onMove(RobocarMove move) {
-    return new RobocarResponse(200, "TODO");
-  }
-
-  @Override
-  public RobocarResponse onSpeed(RobocarSpeed speed) {
-    if (speed == null) {
-      return new RobocarResponse(400, "Bad Request");
+    @Override
+    public void sessionStarted() {
+        switch (cameraMode) {
+            case CAMERA_MODE_ONE:
+                cameraOperator.takePicture();
+                break;
+            case CAMERA_MODE_MULTIPLE:
+                timer = new Timer("CAMERA_TRAINING");
+                timer.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        cameraOperator.takePicture();
+                    }
+                }, 0, 250); // 0 delay, 250 period
+                break;
+        }
     }
-    RobocarSpeedChanger speedChanger = new RobocarSpeedChanger(
-        motorFrontLeft, motorFrontRight, motorBackLeft, motorBackRight);
-    speedChanger.changeSpeed(speed);
-    return new RobocarResponse(200, "OK");
-  }
 
-  private void startSession() {
-    if (!cameraOperator.isInSession()) {
-      cameraOperator.startSession();
-    } else if (cameraMode == CAMERA_MODE_ONE) {
-      sessionStarted();
+    private void endSession() {
+        if (timer != null) {
+            timer.cancel();
+        }
+        cameraOperator.endSession();
     }
-  }
-
-  @Override
-  public void sessionStarted() {
-    switch (cameraMode) {
-      case CAMERA_MODE_ONE:
-        cameraOperator.takePicture();
-        break;
-      case CAMERA_MODE_MULTIPLE:
-        timer = new Timer("CAMERA_TRAINING");
-        timer.schedule(new TimerTask() {
-          @Override
-          public void run() {
-            cameraOperator.takePicture();
-          }
-        }, 0, 250); // 0 delay, 250 period
-        break;
-    }
-  }
-
-  private void endSession() {
-    if (timer != null) {
-      timer.cancel();
-    }
-    cameraOperator.endSession();
-  }
 }

--- a/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitDcMotor.java
+++ b/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitDcMotor.java
@@ -82,4 +82,5 @@ public class AdafruitDcMotor {
   public int getLastSpeed() {
     return lastSpeed;
   }
+
 }

--- a/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitMotorHat.java
+++ b/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitMotorHat.java
@@ -2,7 +2,7 @@ package com.zugaldia.robocar.hardware.adafruit2348;
 
 /**
  * A port of `Adafruit_MotorHAT` to Android Things.
- *
+ * <p>
  * <p>https://github.com/adafruit/Adafruit-Motor-HAT-Python-Library/blob/master/Adafruit_MotorHAT/Adafruit_MotorHAT.py
  */
 
@@ -26,14 +26,14 @@ public class AdafruitMotorHat {
   /**
    * Public constructor.
    */
-  public AdafruitMotorHat() {
-    pwm = new AdafruitPwm();
+  public AdafruitMotorHat(String i2cName, int i2cAddress) {
+    pwm = new AdafruitPwm(i2cName, i2cAddress);
     pwm.setPwmFreq(MOTOR_FREQUENCY);
-    motors = new AdafruitDcMotor[] {
-        new AdafruitDcMotor(this, 0),
-        new AdafruitDcMotor(this, 1),
-        new AdafruitDcMotor(this, 2),
-        new AdafruitDcMotor(this, 3)
+    motors = new AdafruitDcMotor[]{
+            new AdafruitDcMotor(this, 0),
+            new AdafruitDcMotor(this, 1),
+            new AdafruitDcMotor(this, 2),
+            new AdafruitDcMotor(this, 3)
     };
   }
 
@@ -75,4 +75,5 @@ public class AdafruitMotorHat {
   public void close() {
     pwm.close();
   }
+
 }

--- a/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitPwm.java
+++ b/robocar/libhardware/src/main/java/com/zugaldia/robocar/hardware/adafruit2348/AdafruitPwm.java
@@ -11,15 +11,12 @@ import timber.log.Timber;
  * A port of `Adafruit_PWM_Servo_Driver` (Adafruit PCA9685 16-Channel PWM Servo
  * Driver) to Android Things. Instead of using `Adafruit_I2C` we're using the
  * `I2cDevice` class shipped with Android Things.
- *
+ * <p>
  * <p>https://github.com/adafruit/Adafruit-Motor-HAT-Python-Library/blob/master/Adafruit_MotorHAT/Adafruit_PWM_Servo_Driver.py
  * https://developer.android.com/things/sdk/pio/i2c.html
  */
 
 public class AdafruitPwm {
-
-  public static final String I2C_DEVICE_NAME = "I2C1";
-  public static final int I2C_ADDRESS = 0x60;
 
   // Registers
   private static final int __MODE1 = 0x00;
@@ -50,8 +47,8 @@ public class AdafruitPwm {
   /**
    * Public constructor.
    */
-  public AdafruitPwm() {
-    this(I2C_DEVICE_NAME, I2C_ADDRESS, false);
+  public AdafruitPwm(String i2cName, int i2cAddress) {
+    this(i2cName, i2cAddress, true);
   }
 
   /**
@@ -64,7 +61,7 @@ public class AdafruitPwm {
       PeripheralManagerService manager = new PeripheralManagerService();
       i2c = manager.openI2cDevice(deviceName, address);
     } catch (IOException e) {
-      Timber.w(e, "Unable to access I2C device.");
+      Timber.e(e, "Unable to access I2C device.");
     }
 
     this.debug = debug;


### PR DESCRIPTION
Refactored constructor methods of AdafruitPwm and AdafruitMotorHat classes so they can receive the i2c device name and i2c slave device address instead of having them hardcoded.

With the changes I'm commiting and [a new driver](https://github.com/RacZo/adafruit-16-channel-servo-hat-driver) I've written (inspired by Antonio's Motor Hat driver), I was able to stack the [Adafruit 16-Channel PWM Servo Hat](https://learn.adafruit.com/adafruit-16-channel-pwm-servo-hat-for-raspberry-pi) that I'm using to control the pan/tilt bracket's servos my camera module is mounted on, on top of the [Adafruit DC and Stepper Motor HAT](https://learn.adafruit.com/adafruit-dc-and-stepper-motor-hat-for-raspberry-pi).
